### PR TITLE
tests: add <openssl/rand.h> where relevant

### DIFF
--- a/test/test_ipv4.c
+++ b/test/test_ipv4.c
@@ -38,6 +38,7 @@
 #include <openssl/x509.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
+#include <openssl/rand.h>
 
 void generate_master_key(char* passwd, char*  key) {
   unsigned char salt[16];

--- a/test/test_timestamp.c
+++ b/test/test_timestamp.c
@@ -43,6 +43,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <openssl/evp.h>
+#include <openssl/rand.h>
 #include "fnr.h"
 
 #define TRUE 1


### PR DESCRIPTION
The <openssl/rand.h> header file was missing in two places.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>